### PR TITLE
Add data/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+data/


### PR DESCRIPTION
The data/ directory is now ignored by git to prevent accidental commits of local or generated data files.