### PR TITLE
GRAVITY - enhance data visualisation

### DIFF
--- a/examples/case_studies/gravity_uncalibrated_example.ipynb
+++ b/examples/case_studies/gravity_uncalibrated_example.ipynb
@@ -42,7 +42,7 @@
     "- **Calibrated science visibilities** (released in a second phase)  \n",
     "- **Display plots and preview images** for rapid quality assessment  \n",
     "\n",
-    "In the first phase of the release, the primary products are **uncalibrated visibilities**, where detector and instrumental effects have been removed, but atmospheric and transfer-function calibration has not yet been applied. These products are delivered as **OIFITS2** files and are fully ESO Phase 3 compliant.\n",
+    "In the first phase of the release, the primary products are **uncalibrated visibilities**, where detector and instrumental effects have been removed, but atmospheric and transfer-function calibration has not yet been applied. These products are delivered as [**OIFITS2**](https://oifits.org/docs/about/) files and are fully ESO Phase 3 compliant.\n",
     "\n",
     "The release is a growing stream beginning with data from October 2016 onward and processed with pipeline version ≥1.9.\n",
     "\n",
@@ -78,7 +78,7 @@
     "- Resolve a target name to sky coordinates using `SkyCoord.from_name`\n",
     "- Query the ESO Science Archive for nearby **GRAVITY** Phase 3 data products\n",
     "- Retrieve associated raw data products linked to selected `dp_id` values\n",
-    "- Download raw and reduced data products from the ESO Data Portal\n",
+    "- Download raw and reduced data products from the ESO Data Portal (skipped by default, see `download_rawdata` in the setup section)\n",
     "- Retrieve associated ancillary preview products (e.g. `ANCILLARY.PREVIEW`) linked to selected `dp_id` values\n",
     "- Download preview files from the ESO Data Portal\n",
     "- Display preview images side-by-side for rapid comparison\n",
@@ -125,19 +125,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Raw data download will be skipped. If you want such data then set download_rawdata = True\n",
       "Environment Information:\n",
       "\n",
-      "Python       3.10.12\n",
-      "numpy        2.2.6\n",
+      "Python       3.12.0\n",
+      "numpy        2.2.0\n",
       "matplotlib   3.10.8\n",
-      "astropy      6.1.7\n",
-      "requests     2.32.5\n",
+      "astropy      7.0.0\n",
+      "requests     2.32.3\n",
       "tqdm         not installed\n",
-      "astroquery   0.4.12.dev339+ga85d9e4c0\n"
+      "astroquery   0.4.12.dev372+g2238787e7\n"
      ]
     }
    ],
    "source": [
+    "# Change next variable to True to download raw data\n",
+    "download_rawdata = False\n",
+    "if not download_rawdata:\n",
+    "    print (\"Raw data download will be skipped. If you want such data then set download_rawdata = True\")\n",
+    "\n",
+    "\n",
     "# Use postponed evaluation of type hints (PEP 563).\n",
     "# This means annotations are stored as strings and not evaluated at runtime,\n",
     "# making forward references and imports cleaner. Enabled by default in Python ≥3.11.\n",
@@ -215,6 +222,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/home/mellag/.pyenv/versions/science_3.12.0/lib/python3.12/site-packages/pyvo/dal/query.py:341: DALOverflowWarning: Partial result set. Potential causes MAXREC, async storage space, etc.\n",
+      "  warn(\"Partial result set. Potential causes MAXREC, async storage space, etc.\",\n",
       "WARNING: MaxResultsWarning: Results truncated to 2. To retrieve all the records set to None the ROW_LIMIT attribute [astroquery.eso.core]\n"
      ]
     }
@@ -314,7 +323,7 @@
       "        target_name     char                   \n",
       "\n",
       "Number of records present in the table ivoa.ObsCore:\n",
-      "4747365\n",
+      "4759861\n",
       " [astroquery.eso.core]\n"
      ]
     }
@@ -376,18 +385,18 @@
      "text": [
       "INFO: Downloading datasets ... [astroquery.eso.core]\n",
       "INFO: Downloading 2 files ... [astroquery.eso.core]\n",
-      "INFO: Downloading file 1/2 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.439 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-17T14:16:43.439.fits [astroquery.eso.core]\n",
-      "INFO: Downloading file 2/2 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.915 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-18T07:44:57.915.fits [astroquery.eso.core]\n",
+      "INFO: Downloading file 1/2 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.439 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14:16:43.439.fits [astroquery.eso.core]\n",
+      "INFO: Downloading file 2/2 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.915 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07:44:57.915.fits [astroquery.eso.core]\n",
       "INFO: Done! [astroquery.eso.core]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['/data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-17T14:16:43.439.fits',\n",
-       " '/data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-18T07:44:57.915.fits']"
+       "['/home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14:16:43.439.fits',\n",
+       " '/home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07:44:57.915.fits']"
       ]
      },
      "execution_count": 6,
@@ -453,9 +462,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **6. Download Raw Files**\n",
+    "# **6. Optionaly download Raw Files**\n",
     "\n",
-    "Identify provenance columns (``PROV*`` names) in the header table and download the linked files to the local `./data` directory."
+    "Identify provenance columns (``PROV*`` names) in the header table and download the linked files to the local `./data` directory.\n",
+    "\n",
+    "Check `download_rawdata` variable in the setup section to enable or skip raw data download."
    ]
   },
   {
@@ -467,20 +478,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO: Downloading datasets ... [astroquery.eso.core]\n",
-      "INFO: Downloading 2 files ... [astroquery.eso.core]\n",
-      "INFO: Downloading file 1/2 https://dataportal.eso.org/dataPortal/file/GRAVI.2018-01-29T03:34:36.669 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/GRAVI.2018-01-29T03:34:36.669.fits [astroquery.eso.core]\n",
-      "INFO: Downloading file 2/2 https://dataportal.eso.org/dataPortal/file/GRAVI.2020-01-27T02:36:45.844 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/GRAVI.2020-01-27T02:36:45.844.fits [astroquery.eso.core]\n",
-      "INFO: Done! [astroquery.eso.core]\n",
-      "INFO: Downloading datasets ... [astroquery.eso.core]\n",
-      "INFO: Downloading 2 files ... [astroquery.eso.core]\n",
-      "INFO: Downloading file 1/2 https://dataportal.eso.org/dataPortal/file/GRAVI.2018-01-29T03:45:57.697 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/GRAVI.2018-01-29T03:45:57.697.fits [astroquery.eso.core]\n",
-      "INFO: Downloading file 2/2 https://dataportal.eso.org/dataPortal/file/GRAVI.2020-01-27T02:42:18.859 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/GRAVI.2020-01-27T02:42:18.859.fits [astroquery.eso.core]\n",
-      "INFO: Done! [astroquery.eso.core]\n"
+      "Raw data associated from Provenance  :             PROV1            \n",
+      "-----------------------------\n",
+      "GRAVI.2018-01-29T03:34:36.669\n",
+      "GRAVI.2020-01-27T02:36:45.844\n",
+      "Raw data associated from Provenance  :             PROV2            \n",
+      "-----------------------------\n",
+      "GRAVI.2018-01-29T03:45:57.697\n",
+      "GRAVI.2020-01-27T02:42:18.859\n"
      ]
     }
    ],
@@ -492,7 +497,13 @@
     "for colname in colnames_prov:\n",
     "    # retrieve_data requires file IDs and not file names: FITS extensions must be removed, other extensions (e.g. .tar) are part of the ID.\n",
     "    table_headers[colname] = [re.sub(r\"\\.fits.*$\", \"\", f) for f in table_headers[colname]]\n",
-    "    eso.retrieve_data(table_headers[colname], destination=\"./data\")"
+    "    # \n",
+    "    if download_rawdata :\n",
+    "        eso.retrieve_data(table_headers[colname], destination=\"./data\")\n",
+    "    else:\n",
+    "        print(f\"\"\"Raw data associated from Provenance  : {table_headers[colname]}\"\"\")\n",
+    "        \n",
+    "    "
    ]
   },
   {
@@ -515,14 +526,14 @@
      "text": [
       "INFO: Downloading datasets ... [astroquery.eso.core]\n",
       "INFO: Downloading 4 files ... [astroquery.eso.core]\n",
-      "INFO: Downloading file 1/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.440 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-17T14:16:43.440.png [astroquery.eso.core]\n",
-      "INFO: Downloading file 2/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.441 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-17T14:16:43.441.png [astroquery.eso.core]\n",
-      "INFO: Downloading file 3/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.916 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-18T07:44:57.916.png [astroquery.eso.core]\n",
-      "INFO: Downloading file 4/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.917 to /data/amicol/astroquery_examples/examples/case_studies/data [astroquery.eso.core]\n",
-      "INFO: Found cached file /data/amicol/astroquery_examples/examples/case_studies/data/ADP.2025-12-18T07:44:57.917.png [astroquery.eso.core]\n",
+      "INFO: Downloading file 1/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.440 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14:16:43.440.png [astroquery.eso.core]\n",
+      "INFO: Downloading file 2/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.441 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14:16:43.441.png [astroquery.eso.core]\n",
+      "INFO: Downloading file 3/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.916 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07:44:57.916.png [astroquery.eso.core]\n",
+      "INFO: Downloading file 4/4 https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.917 to /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data [astroquery.eso.core]\n",
+      "INFO: Found cached file /home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07:44:57.917.png [astroquery.eso.core]\n",
       "INFO: Done! [astroquery.eso.core]\n"
      ]
     }
@@ -687,11 +698,100 @@
    "source": [
     "print(\"\\nAll done! You can now explore the downloaded data and ancillary files in the './data/' directory.\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "datadir=Path(\"./data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use external tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute the oifits filenames associated to collected data_products\n",
+    "oifits_files=[(datadir/(dp_id+\".fits\")).absolute().as_uri() for dp_id in table[\"dp_id\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this cell could be moved in the helper directory or JMMC/a2p2 module\n",
+    "import tempfile\n",
+    "from astropy.samp import SAMPIntegratedClient\n",
+    "client = SAMPIntegratedClient()\n",
+    "    \n",
+    "def sendSampOiFitsExplorerCollection(filenames):    \n",
+    "    # prepare payload in a temporary file\n",
+    "    mycolFilename=tempfile.NamedTemporaryFile(mode='w+', suffix=\"mycol.oixp\", delete=False)\n",
+    "    file_urls= [ f\"\\n  <file><file>{filename}</file></file>\" for filename in filenames ]\n",
+    "    buffer=f\"<oixp:oiDataCollection xmlns:oixp='http://www.jmmc.fr/oiexplorer-data-collection/0.1'>{''.join( file_urls) }\\n\\r</oixp:oiDataCollection>\"                                \n",
+    "    mycolFilename.write(buffer)\n",
+    "    # prepare message and broadcast it\n",
+    "    mycolUrl=Path(mycolFilename.name).absolute().as_uri()\n",
+    "    message = { \"samp.mtype\" : \"fr.jmmc.oiexplorer.load.collection\", \"samp.params\" : {\"url\" : mycolUrl} }\n",
+    "    try:\n",
+    "        # check client\n",
+    "        if not client.is_connected:\n",
+    "            client.connect()    \n",
+    "        receiver_ids = client.notify_all(message)\n",
+    "        print(f\"{mycolUrl} collection ({len(filenames)} oifits) sent by samp\")    \n",
+    "    except:\n",
+    "        print(f\"Error trying to send a SAMP message. Please check that OIfitsExplorer is running or visit :\\n  https://www.jmmc.fr/oifitsexplorer \")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load and visualize oifits collection into OiFitsExplorer "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error trying to send a samp message. Please check that OIfitsExplorer is running or visit :\n",
+      "  https://www.jmmc.fr/oifitsexplorer \n"
+     ]
+    }
+   ],
+   "source": [
+    "sendSampOiFitsExplorerCollection(oifits_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ipa-default",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -705,7 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/examples/case_studies/gravity_uncalibrated_example.ipynb
+++ b/examples/case_studies/gravity_uncalibrated_example.ipynb
@@ -325,7 +325,7 @@
       "        target_name     char                   \n",
       "\n",
       "Number of records present in the table ivoa.ObsCore:\n",
-      "4765744\n",
+      "4768497\n",
       " [astroquery.eso.core]\n"
      ]
     }
@@ -712,32 +712,21 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14%3A16%3A43.439.fits',\n",
-       " 'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07%3A44%3A57.915.fits']"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "datadir=Path(\"./data\")\n",
-    "# compute the oifits filenames associated to collected data_products\n",
+    "# compute the oifits filenames and urls associated to collected data_products\n",
     "oifits_files=[(datadir/(dp_id+\".fits\")).absolute().as_uri() for dp_id in table[\"dp_id\"]]\n",
-    "oifits_files"
+    "oifits_urls=[ eso.DOWNLOAD_URL+dp_id for dp_id in table[\"dp_id\"]]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load oifits onto remote applications "
+    "# Load local oifits onto external applications\n",
+    "( does not work if you do not run the notebook kernel on your machine )"
    ]
   },
   {
@@ -749,17 +738,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error trying to send a SAMP message. \n",
-      "Please check that you are running a VO compliant application ( with table.load.fits support ). \n",
-      "You can try :\n",
-      " - OIFitsExplorer ( https://www.jmmc.fr/oifitsexplorer ) \n",
-      " - OImaging       ( https://www.jmmc.fr/oimaging ) - only use the last submitted oifits\n",
-      " - LITpro         ( https://www.jmmc.fr/litpro ) \n"
+      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14%3A16%3A43.439.fits' sent to OIFitsExplorer, LITpro, OImaging\n",
+      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07%3A44%3A57.915.fits' sent to OIFitsExplorer, LITpro, OImaging\n"
      ]
     }
    ],
    "source": [
     "sendOiFitsWithSAMP(oifits_files)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load remote oifits onto external applications\n",
+    "( does work even if you do not run the notebook kernel on your machine, eg. mybinder )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.439' sent to OIFitsExplorer, LITpro, OImaging\n",
+      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.915' sent to OIFitsExplorer, LITpro, OImaging\n"
+     ]
+    }
+   ],
+   "source": [
+    "#https://dataportal.eso.org/dataPortal/file/\n",
+    "sendOiFitsWithSAMP(oifits_urls"
    ]
   },
   {

--- a/examples/case_studies/gravity_uncalibrated_example.ipynb
+++ b/examples/case_studies/gravity_uncalibrated_example.ipynb
@@ -738,8 +738,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14%3A16%3A43.439.fits' sent to OIFitsExplorer, LITpro, OImaging\n",
-      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07%3A44%3A57.915.fits' sent to OIFitsExplorer, LITpro, OImaging\n"
+      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14%3A16%3A43.439.fits' sent to LITpro, OIFitsExplorer, OImaging\n",
+      "'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07%3A44%3A57.915.fits' sent to LITpro, OIFitsExplorer, OImaging\n"
      ]
     }
    ],
@@ -770,20 +770,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.439' sent to OIFitsExplorer, LITpro, OImaging\n",
-      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.915' sent to OIFitsExplorer, LITpro, OImaging\n"
+      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-17T14:16:43.439' sent to LITpro, OIFitsExplorer, OImaging\n",
+      "'https://dataportal.eso.org/dataPortal/file/ADP.2025-12-18T07:44:57.915' sent to LITpro, OIFitsExplorer, OImaging\n"
      ]
     }
    ],
    "source": [
     "#https://dataportal.eso.org/dataPortal/file/\n",
-    "sendOiFitsWithSAMP(oifits_urls"
+    "sendOiFitsWithSAMP(oifits_urls)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/examples/case_studies/gravity_uncalibrated_example.ipynb
+++ b/examples/case_studies/gravity_uncalibrated_example.ipynb
@@ -166,6 +166,8 @@
     "\n",
     "# --- Helpers ---\n",
     "from helpers.gravity import prepare_eso\n",
+    "from helpers.jmmc import sendOiFitsWithSAMP\n",
+    "\n",
     "\n",
     "# Print key package and python versions\n",
     "print(\"Environment Information:\\n\")\n",
@@ -323,7 +325,7 @@
       "        target_name     char                   \n",
       "\n",
       "Number of records present in the table ivoa.ObsCore:\n",
-      "4759861\n",
+      "4765744\n",
       " [astroquery.eso.core]\n"
      ]
     }
@@ -700,16 +702,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "datadir=Path(\"./data\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -718,67 +710,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-17T14%3A16%3A43.439.fits',\n",
+       " 'file:///home/mellaData/git/eso/astroquery_examples_gmella/examples/case_studies/data/ADP.2025-12-18T07%3A44%3A57.915.fits']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "from pathlib import Path\n",
+    "datadir=Path(\"./data\")\n",
     "# compute the oifits filenames associated to collected data_products\n",
-    "oifits_files=[(datadir/(dp_id+\".fits\")).absolute().as_uri() for dp_id in table[\"dp_id\"]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this cell could be moved in the helper directory or JMMC/a2p2 module\n",
-    "import tempfile\n",
-    "from astropy.samp import SAMPIntegratedClient\n",
-    "client = SAMPIntegratedClient()\n",
-    "    \n",
-    "def sendSampOiFitsExplorerCollection(filenames):    \n",
-    "    # prepare payload in a temporary file\n",
-    "    mycolFilename=tempfile.NamedTemporaryFile(mode='w+', suffix=\"mycol.oixp\", delete=False)\n",
-    "    file_urls= [ f\"\\n  <file><file>{filename}</file></file>\" for filename in filenames ]\n",
-    "    buffer=f\"<oixp:oiDataCollection xmlns:oixp='http://www.jmmc.fr/oiexplorer-data-collection/0.1'>{''.join( file_urls) }\\n\\r</oixp:oiDataCollection>\"                                \n",
-    "    mycolFilename.write(buffer)\n",
-    "    # prepare message and broadcast it\n",
-    "    mycolUrl=Path(mycolFilename.name).absolute().as_uri()\n",
-    "    message = { \"samp.mtype\" : \"fr.jmmc.oiexplorer.load.collection\", \"samp.params\" : {\"url\" : mycolUrl} }\n",
-    "    try:\n",
-    "        # check client\n",
-    "        if not client.is_connected:\n",
-    "            client.connect()    \n",
-    "        receiver_ids = client.notify_all(message)\n",
-    "        print(f\"{mycolUrl} collection ({len(filenames)} oifits) sent by samp\")    \n",
-    "    except:\n",
-    "        print(f\"Error trying to send a SAMP message. Please check that OIfitsExplorer is running or visit :\\n  https://www.jmmc.fr/oifitsexplorer \")    "
+    "oifits_files=[(datadir/(dp_id+\".fits\")).absolute().as_uri() for dp_id in table[\"dp_id\"]]\n",
+    "oifits_files"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load and visualize oifits collection into OiFitsExplorer "
+    "# Load oifits onto remote applications "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error trying to send a samp message. Please check that OIfitsExplorer is running or visit :\n",
-      "  https://www.jmmc.fr/oifitsexplorer \n"
+      "Error trying to send a SAMP message. \n",
+      "Please check that you are running a VO compliant application ( with table.load.fits support ). \n",
+      "You can try :\n",
+      " - OIFitsExplorer ( https://www.jmmc.fr/oifitsexplorer ) \n",
+      " - OImaging       ( https://www.jmmc.fr/oimaging ) - only use the last submitted oifits\n",
+      " - LITpro         ( https://www.jmmc.fr/litpro ) \n"
      ]
     }
    ],
    "source": [
-    "sendSampOiFitsExplorerCollection(oifits_files)"
+    "sendOiFitsWithSAMP(oifits_files)"
    ]
   },
   {

--- a/examples/case_studies/helpers/__init__.py
+++ b/examples/case_studies/helpers/__init__.py
@@ -1,3 +1,4 @@
 from .gravity import prepare_eso
+from .jmmc import sendOiFitsWithSAMP
 
-__all__ = ["prepare_eso"]
+__all__ = ["prepare_eso", "sendOiFitsWithSAMP"]

--- a/examples/case_studies/helpers/jmmc.py
+++ b/examples/case_studies/helpers/jmmc.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from astropy.samp import SAMPIntegratedClient
+client = SAMPIntegratedClient()
+
+def sendOiFitsWithSAMP(filenames):
+    """ Loop and send each files through SAMP usig table.load.fits messages. """
+    try:
+        if not client.is_connected:
+            client.connect()            
+        for url in filenames:
+            #input(f"Press Enter to send {url} ...")        
+            message = { "samp.mtype" : "table.load.fits", "samp.params" : {"url" : url} }
+            receivers = [ client.get_metadata(id)['samp.name'] for id in client.notify_all(message)]
+            print( f"'{url}' sent to {', '.join(receivers)}" )        
+    except:
+        print(f"Error trying to send a SAMP message. \nPlease check that you are running a VO compliant application ( with table.load.fits support ). \nYou can try :")
+        print(" - OIFitsExplorer ( https://www.jmmc.fr/oifitsexplorer ) ")    
+        print(" - OImaging       ( https://www.jmmc.fr/oimaging ) - only use the last submitted oifits")    
+        print(" - LITpro         ( https://www.jmmc.fr/litpro ) ") 


### PR DESCRIPTION
Notes from email: 

> You will find at the following fork an updated version of Ashley/eso’s notebook that includes at the end the “Use external source” and “load onto remote applications” cells that use the SAMP protocol to load the oifits data downloaded to the JMMC applications : OiFitsExplorer, LitPro and OImaging.
> Many thanks to Guillaume Mella for putting that together. 
> 
> https://github.com/gmella/astroquery_examples/blob/main/examples/case_studies/gravity_uncalibrated_example.ipynb
> 
> In addition to the notebook itself the helper jmmc.py has to be put in the helper directory (https://github.com/gmella/astroquery_examples/tree/main/examples/case_studies/helpers)