### PR TITLE
Improve GRAVITY example notebook & helper - Isabelle Percheron feedback

### DIFF
--- a/examples/case_studies/data/esorex.log
+++ b/examples/case_studies/data/esorex.log
@@ -1,126 +1,126 @@
 
-Start time     : 2026-04-17T15:53:39
+Start time     : 2026-04-28T11:30:49
 Program name   : esorex
 Severity level : [ INFO  ] 
 
-15:53:39 [ INFO  ] : This is EsoRex, version 3.13.10
-15:53:39 [ INFO  ] : using the libraries: CPL = 7.3.2, CFITSIO = 4.4.1, WCSLIB = 8.2.2, FFTW (normal precision) = 3.3.10, FFTW (single precision) = 3.3.10
-15:53:39 [ INFO  ] : Invocation command line was: /opt/local/bin/esorex gravity_viscal --force-calib=true viscal.sof
-15:53:39 [ INFO  ] gravity_print_banner: **********************************************
-15:53:39 [ INFO  ] gravity_print_banner:   Welcome to GRAVITY Pipeline release 1.9.4
-15:53:39 [ INFO  ] gravity_print_banner:   Last rebuilt at Jul 28 2025 11:10:45
-15:53:39 [ INFO  ] gravity_print_banner: **********************************************
-15:53:39 [ INFO  ] gravity_viscal: Start function gravity_viscal
-15:53:39 [ INFO  ] gravi_data_load_frame: Load file M.GRAVITY.2020-06-10T12:25:17.246.fits (DIAMETER_CAT)
-15:53:42 [ INFO  ] gravity_viscal: *** Compute TF 1 over 1 ***
-15:53:42 [ INFO  ] gravi_data_load_frame: Load file ADP.2025-12-24T13:09:34.519.fits (SINGLE_CAL_VIS)
-15:53:42 [ INFO  ] gravi_data_dump_mode: (insmode: HIGH COMBINED COMBINED)
-15:53:42 [ INFO  ] gravi_compute_tf: Start function gravi_compute_tf
-15:53:42 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
-15:53:42 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001465 s)
-15:53:42 [ INFO  ] gravi_compute_tf: Find match in DIAMETER_CAT (best sep=0.02 arcsec)
-15:53:42 [ INFO  ] gravi_compute_tf: Diameter for SC target: 0.621 (+-0.010) mas
-15:53:42 [ INFO  ] gravi_compute_tf: Use ATs
-15:53:42 [ INFO  ] gravi_compute_tf: Use Kmag=4.44 for QC.TRANS
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC1 = 1.07%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC2 = 0.82%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC3 = 0.80%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC4 = 1.01%
-15:53:42 [ INFO  ] gravi_compute_tf: Find match in DIAMETER_CAT (best sep=0.02 arcsec)
-15:53:42 [ INFO  ] gravi_compute_tf: Diameter for FT target: 0.621 (+-0.010) mas
-15:53:42 [ INFO  ] gravi_compute_tf: Use ATs
-15:53:42 [ INFO  ] gravi_compute_tf: Use Kmag=4.44 for QC.TRANS
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT1 = 0.86%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT2 = 0.82%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT3 = 0.82%
-15:53:42 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT4 = 0.71%
-15:53:42 [ INFO  ] gravi_compute_tf: Exit function gravi_compute_tf (0.106235 s)
-15:53:42 [ INFO  ] gravi_vis_smooth: Start function gravi_vis_smooth
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000006 s)
-15:53:42 [ INFO  ] gravi_vis_smooth: Smoothing OIFITS2 FLUXDATA column
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VIS2DATA
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VIS2ERR
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000264 s)
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002081 s)
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VISAMP
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VISAMPERR
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VISPHI
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column VISPHIERR
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000434 s)
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [ INFO  ] gravi_vis_smooth_phi: Start function gravi_vis_smooth_phi
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002120 s)
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002221 s)
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [WARNING] FIXME: ***********************************************
-15:53:42 [WARNING] FIXME:                                                
-15:53:42 [WARNING] FIXME:  VISDATA is not properly smooth !! 
-15:53:42 [WARNING] FIXME:                                                
-15:53:42 [WARNING] FIXME: ***********************************************
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column T3PHI
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column T3PHIERR
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column T3AMP
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Check column T3AMPERR
-15:53:42 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000378 s)
-15:53:42 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
-15:53:42 [ INFO  ] gravi_vis_smooth_phi: Start function gravi_vis_smooth_phi
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.001376 s)
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
-15:53:42 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.001439 s)
-15:53:42 [ INFO  ] gravi_vis_smooth: Exit function gravi_vis_smooth (0.012318 s)
-15:53:42 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
-15:53:42 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000056 s)
-15:53:42 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
-15:53:42 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.519_singlecaltf.fits
-15:53:42 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_CAL_TF): ADP.2025-12-24T13:09:34.519_singlecaltf.fits
-15:53:42 [ INFO  ] gravity_viscal: *** Load already computed TF ***
-15:53:42 [ INFO  ] gravity_viscal: *** All TF computed or loaded ***
-15:53:42 [ INFO  ] gravity_viscal: Load or create successfully 1 TF over 1 input CAL files
-15:53:42 [ INFO  ] gravity_viscal: *** Calibration of file 1 over 1 ***
-15:53:42 [ INFO  ] gravi_data_load_frame: Load file ADP.2025-12-24T13:09:34.525.fits (SINGLE_SCI_VIS)
-15:53:42 [ INFO  ] gravi_data_dump_mode: (insmode: HIGH COMBINED COMBINED)
-15:53:42 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
-15:53:42 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001528 s)
-15:53:42 [ INFO  ] gravi_calibrate_vis: Start function gravi_calibrate_vis
-15:53:42 [ INFO  ] gravi_calibrate_vis: Number of possible TF: 1
-15:53:42 [ INFO  ] gravi_calibrate_vis: Delta time to interpolate the TF: 3600.000000 s (1.000000 h)
-15:53:42 [ INFO  ] gravi_calibrate_vis: Force calibration of the SCI by CALs: T
-15:53:42 [ INFO  ] gravi_calibrate_vis: Setup of SCIENCE:       HIGH COMBINED COMBINED 0.85ms 100.00s
-15:53:42 [ INFO  ] gravi_calibrate_vis: Setup of TF file:       HIGH COMBINED COMBINED 0.85ms 30.00s -> keep  (force_calib)
-15:53:42 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
-15:53:42 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001499 s)
-15:53:42 [ INFO  ] gravi_calibrate_vis: Exit function gravi_calibrate_vis (0.008549 s)
-15:53:42 [ INFO  ] gravity_viscal: Computing QC parameters for calibrated visibilities
-15:53:42 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
-15:53:42 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000066 s)
-15:53:42 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
-15:53:42 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits
-15:53:42 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_SCI_VIS_CALIBRATED): ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits
-15:53:43 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
-15:53:43 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000060 s)
-15:53:43 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
-15:53:43 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.525_singlescitf.fits
-15:53:43 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_SCI_TF): ADP.2025-12-24T13:09:34.525_singlescitf.fits
-15:53:43 [ INFO  ] gravity_viscal: Memory cleanup
-15:53:43 [ INFO  ] gravity_viscal: Exit function gravity_viscal (3.112892 s)
-15:53:43 [ INFO  ] : Calculating product checksums
-15:53:43 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.519_singlecaltf.fits (in place)
-15:53:43 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits (in place)
-15:53:43 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.525_singlescitf.fits (in place)
-15:53:43 [ INFO  ] : 3 products created
-15:53:43 [ INFO  ] : Recipe operation(s) took           3.48 seconds to complete.
-15:53:43 [ INFO  ] : Total size of 2 raw input frames  =    38.37 MB
+11:30:49 [ INFO  ] : This is EsoRex, version 3.13.10
+11:30:49 [ INFO  ] : using the libraries: CPL = 7.3.2, CFITSIO = 4.4.1, WCSLIB = 8.2.2, FFTW (normal precision) = 3.3.10, FFTW (single precision) = 3.3.10
+11:30:49 [ INFO  ] : Invocation command line was: /opt/local/bin/esorex gravity_viscal --force-calib=true viscal.sof
+11:30:49 [ INFO  ] gravity_print_banner: **********************************************
+11:30:49 [ INFO  ] gravity_print_banner:   Welcome to GRAVITY Pipeline release 1.9.4
+11:30:49 [ INFO  ] gravity_print_banner:   Last rebuilt at Jul 28 2025 11:10:45
+11:30:49 [ INFO  ] gravity_print_banner: **********************************************
+11:30:49 [ INFO  ] gravity_viscal: Start function gravity_viscal
+11:30:49 [ INFO  ] gravi_data_load_frame: Load file M.GRAVITY.2020-06-10T12:25:17.246.fits (DIAMETER_CAT)
+11:30:52 [ INFO  ] gravity_viscal: *** Compute TF 1 over 1 ***
+11:30:52 [ INFO  ] gravi_data_load_frame: Load file ADP.2025-12-24T13:09:34.519.fits (SINGLE_CAL_VIS)
+11:30:52 [ INFO  ] gravi_data_dump_mode: (insmode: HIGH COMBINED COMBINED)
+11:30:52 [ INFO  ] gravi_compute_tf: Start function gravi_compute_tf
+11:30:52 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
+11:30:52 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001604 s)
+11:30:52 [ INFO  ] gravi_compute_tf: Find match in DIAMETER_CAT (best sep=0.02 arcsec)
+11:30:52 [ INFO  ] gravi_compute_tf: Diameter for SC target: 0.621 (+-0.010) mas
+11:30:52 [ INFO  ] gravi_compute_tf: Use ATs
+11:30:52 [ INFO  ] gravi_compute_tf: Use Kmag=4.44 for QC.TRANS
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC1 = 1.07%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC2 = 0.82%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC3 = 0.80%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_SC4 = 1.01%
+11:30:52 [ INFO  ] gravi_compute_tf: Find match in DIAMETER_CAT (best sep=0.02 arcsec)
+11:30:52 [ INFO  ] gravi_compute_tf: Diameter for FT target: 0.621 (+-0.010) mas
+11:30:52 [ INFO  ] gravi_compute_tf: Use ATs
+11:30:52 [ INFO  ] gravi_compute_tf: Use Kmag=4.44 for QC.TRANS
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT1 = 0.86%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT2 = 0.82%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT3 = 0.82%
+11:30:52 [ INFO  ] gravi_compute_tf: ESO QC TF TRANS_FT4 = 0.71%
+11:30:52 [ INFO  ] gravi_compute_tf: Exit function gravi_compute_tf (0.108521 s)
+11:30:52 [ INFO  ] gravi_vis_smooth: Start function gravi_vis_smooth
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000024 s)
+11:30:52 [ INFO  ] gravi_vis_smooth: Smoothing OIFITS2 FLUXDATA column
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VIS2DATA
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VIS2ERR
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000279 s)
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002362 s)
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VISAMP
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VISAMPERR
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VISPHI
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column VISPHIERR
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000498 s)
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [ INFO  ] gravi_vis_smooth_phi: Start function gravi_vis_smooth_phi
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002081 s)
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.002166 s)
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [WARNING] FIXME: ***********************************************
+11:30:52 [WARNING] FIXME:                                                
+11:30:52 [WARNING] FIXME:  VISDATA is not properly smooth !! 
+11:30:52 [WARNING] FIXME:                                                
+11:30:52 [WARNING] FIXME: ***********************************************
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Start function gravi_vis_flag_nan
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column T3PHI
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column T3PHIERR
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column T3AMP
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Check column T3AMPERR
+11:30:52 [ INFO  ] gravi_vis_flag_nan: Exit function gravi_vis_flag_nan (0.000437 s)
+11:30:52 [ INFO  ] gravi_vis_smooth_amp: Start function gravi_vis_smooth_amp
+11:30:52 [ INFO  ] gravi_vis_smooth_phi: Start function gravi_vis_smooth_phi
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.001374 s)
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Start function gravi_vis_fit_amp
+11:30:52 [ INFO  ] gravi_vis_fit_amp: Exit function gravi_vis_fit_amp (0.001359 s)
+11:30:52 [ INFO  ] gravi_vis_smooth: Exit function gravi_vis_smooth (0.013754 s)
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000080 s)
+11:30:52 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
+11:30:52 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.519_singlecaltf.fits
+11:30:52 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_CAL_TF): ADP.2025-12-24T13:09:34.519_singlecaltf.fits
+11:30:52 [ INFO  ] gravity_viscal: *** Load already computed TF ***
+11:30:52 [ INFO  ] gravity_viscal: *** All TF computed or loaded ***
+11:30:52 [ INFO  ] gravity_viscal: Load or create successfully 1 TF over 1 input CAL files
+11:30:52 [ INFO  ] gravity_viscal: *** Calibration of file 1 over 1 ***
+11:30:52 [ INFO  ] gravi_data_load_frame: Load file ADP.2025-12-24T13:09:34.525.fits (SINGLE_SCI_VIS)
+11:30:52 [ INFO  ] gravi_data_dump_mode: (insmode: HIGH COMBINED COMBINED)
+11:30:52 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
+11:30:52 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001678 s)
+11:30:52 [ INFO  ] gravi_calibrate_vis: Start function gravi_calibrate_vis
+11:30:52 [ INFO  ] gravi_calibrate_vis: Number of possible TF: 1
+11:30:52 [ INFO  ] gravi_calibrate_vis: Delta time to interpolate the TF: 3600.000000 s (1.000000 h)
+11:30:52 [ INFO  ] gravi_calibrate_vis: Force calibration of the SCI by CALs: T
+11:30:52 [ INFO  ] gravi_calibrate_vis: Setup of SCIENCE:       HIGH COMBINED COMBINED 0.85ms 100.00s
+11:30:52 [ INFO  ] gravi_calibrate_vis: Setup of TF file:       HIGH COMBINED COMBINED 0.85ms 30.00s -> keep  (force_calib)
+11:30:52 [ INFO  ] gravi_data_duplicate: Start function gravi_data_duplicate
+11:30:52 [ INFO  ] gravi_data_duplicate: Exit function gravi_data_duplicate (0.001685 s)
+11:30:52 [ INFO  ] gravi_calibrate_vis: Exit function gravi_calibrate_vis (0.008691 s)
+11:30:52 [ INFO  ] gravity_viscal: Computing QC parameters for calibrated visibilities
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000064 s)
+11:30:52 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
+11:30:52 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits
+11:30:52 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_SCI_VIS_CALIBRATED): ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Start function gravi_plist_get_oifits_keywords
+11:30:52 [ INFO  ] gravi_plist_get_oifits_keywords: Exit function gravi_plist_get_oifits_keywords (0.000068 s)
+11:30:52 [ INFO  ] gravi_pfits_add_pipe_build: ESO PRO REC1 PIPE LAST_BUILD = 'Jul 28 2025 11:10:45'
+11:30:52 [ INFO  ] gravi_data_save_new: Save file to ADP.2025-12-24T13:09:34.525_singlescitf.fits
+11:30:52 [ INFO  ] cpl_dfs_product_save: Writing FITS propertylist product(SINGLE_SCI_TF): ADP.2025-12-24T13:09:34.525_singlescitf.fits
+11:30:52 [ INFO  ] gravity_viscal: Memory cleanup
+11:30:52 [ INFO  ] gravity_viscal: Exit function gravity_viscal (3.143134 s)
+11:30:52 [ INFO  ] : Calculating product checksums
+11:30:52 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.519_singlecaltf.fits (in place)
+11:30:52 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.525_singlesciviscalibrated.fits (in place)
+11:30:52 [ INFO  ] : Created product ADP.2025-12-24T13:09:34.525_singlescitf.fits (in place)
+11:30:52 [ INFO  ] : 3 products created
+11:30:52 [ INFO  ] : Recipe operation(s) took           3.58 seconds to complete.
+11:30:52 [ INFO  ] : Total size of 2 raw input frames  =    38.37 MB
 
-15:53:43 [ INFO  ] : => processing rate of    11.03 MB/sec 
+11:30:52 [ INFO  ] : => processing rate of    10.71 MB/sec 
 

--- a/examples/case_studies/helpers/gravity.py
+++ b/examples/case_studies/helpers/gravity.py
@@ -6,8 +6,10 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.table import vstack
+from astroquery.eso import Eso
 from PIL import Image
 from matplotlib import pyplot as plt
+import sys
 
 def _normalize_product_ids(dp_id):
     if dp_id is None:
@@ -296,6 +298,32 @@ def select_calibrators(table, colname="HIERARCH ESO PRO CATG", pattern="CAL"):
     return table[mask]
 
 
+def _dp_id_column(table):
+    for colname in ("dp_id", "DP.ID"):
+        if colname in table.colnames:
+            return colname
+    raise KeyError("Expected a product id column named 'dp_id' or 'DP.ID'.")
+
+
+def _science_dp_ids_from_headers(table_headers):
+    """
+    Return header DP.ID values not classified as calibrators.
+    """
+    dp_col = _dp_id_column(table_headers)
+    calibrator_ids = set(select_calibrators(table_headers)[dp_col].astype(str))
+    return [
+        str(dp_id)
+        for dp_id in table_headers[dp_col]
+        if str(dp_id) not in calibrator_ids
+    ]
+
+
+def _format_dp_id_list(dp_ids):
+    if not dp_ids:
+        return "  (none)"
+    return "\n".join(f"  - {dp_id}" for dp_id in dp_ids)
+
+
 def select_time_window(table, date_obs, window_hours=6, colname="DATE-OBS"):
     """
     Return rows within ±window_hours of the reference observation time.
@@ -308,12 +336,14 @@ def select_time_window(table, date_obs, window_hours=6, colname="DATE-OBS"):
 
 
 def get_science_and_calibrator(
-    eso,
-    target,
+    *args,
+    target=None,
     radius=20 * u.arcsec,
     window_hours=6,
     destination="./data/",
     survey="GRAVITY",
+    dp_id=None,
+    dp_id_cal=None,
     get_preview=True,
     show_preview=True,
 ):
@@ -322,16 +352,17 @@ def get_science_and_calibrator(
     download the selected files, and optionally retrieve/display ancillary
     preview products.
 
-    This function currently assumes that the archive query returns exactly one
-    science product for the target, and that the calibrator matching procedure
-    yields exactly one calibrator product. If either step returns zero or
-    multiple matches, a warning is raised and the function exits so that the
-    user can refine the selection manually.
+    This function assumes that the archive query returns exactly one science
+    product for the target unless `dp_id` is provided. When `dp_id` is provided,
+    it is used to select the science product from the target/radius search
+    results after checking that the product is not classified as a calibrator.
+    The calibrator matching procedure expects exactly one calibrator product
+    unless `dp_id_cal` is provided. If either step returns zero or multiple
+    matches, a warning is raised and the function exits so that the user can
+    refine the selection manually.
 
     Parameters
     ----------
-    eso : astroquery.eso.Eso
-        Initialised ESO query object.
     target : str
         Target name resolvable by `SkyCoord.from_name`.
     radius : astropy.units.Quantity, optional
@@ -342,6 +373,14 @@ def get_science_and_calibrator(
         Directory where files will be downloaded.
     survey : str, optional
         Survey/collection name to query. Default is "GRAVITY".
+    dp_id : str, optional
+        Science product id to select from the target/radius query results.
+        The product must belong to the target query and must not be classified
+        as a calibrator.
+    dp_id_cal : str, optional
+        Calibrator product id to select when the calibrator matching procedure
+        returns multiple candidates. The product must be one of the matched
+        calibrator candidates.
     get_preview : bool, optional
         If True, query and download ancillary preview products.
     show_preview : bool, optional
@@ -361,6 +400,25 @@ def get_science_and_calibrator(
         Associated ancillary preview table with local filenames if requested,
         otherwise None.
     """
+    if len(args) > 1 or (args and target is not None):
+        raise TypeError(
+            "get_science_and_calibrator() now creates its ESO query object "
+            "internally. Call it as get_science_and_calibrator(target=..., "
+            "radius=..., dp_id=...) without passing eso."
+        )
+    if args:
+        target = args[0]
+    if target is None:
+        raise TypeError("get_science_and_calibrator() missing required argument: 'target'")
+    if not isinstance(target, str):
+        raise TypeError(
+            "get_science_and_calibrator() now creates its ESO query object "
+            "internally. Call it as get_science_and_calibrator(target=..., "
+            "radius=..., dp_id=...) without passing eso."
+        )
+
+    eso = prepare_eso(Eso)
+
     # Resolve the target name to sky coordinates
     coords = SkyCoord.from_name(target)
     ra = coords.ra.deg
@@ -376,17 +434,90 @@ def get_science_and_calibrator(
         cone_radius=radius_deg,
     )
 
-    # This simple example expects exactly one science match
-    if len(table_target) != 1:
+    if len(table_target) == 0:
         warnings.warn(
             f"Expected exactly 1 science product for target '{target}', "
-            f"but found {len(table_target)}. "
-            "Please refine the target selection manually."
+            "but found 0. Please refine the target selection manually."
         )
         return None, None, None, None
 
-    # Retrieve detailed headers for the selected science product
     table_target_hrd = eso.get_headers(table_target["dp_id"])
+    science_dp_ids = _science_dp_ids_from_headers(table_target_hrd)
+
+    def _print_dp_id_list(dp_ids, title="Science candidate dp_id values"):
+        print("\n" + "=" * 80)
+        print(f"{title} ({len(dp_ids)}):")
+        print("=" * 80)
+        print(_format_dp_id_list(dp_ids))
+        print("=" * 80 + "\n")
+
+    def _selection_example(param_name, dp_ids):
+        if not dp_ids:
+            return ""
+        return (
+            " For example: "
+            f'get_science_and_calibrator(target=..., radius=..., {param_name}="{dp_ids[0]}")'
+        )
+
+    if dp_id is not None:
+        dp_id = str(dp_id).strip()
+        if not dp_id:
+            raise ValueError("dp_id must be a non-empty product id string.")
+        if dp_id not in set(table_target["dp_id"].astype(str)):
+            raise ValueError(
+                f"Science product dp_id '{dp_id}' was not found in the "
+                f"target/radius query results for '{target}'."
+            )
+        if dp_id not in science_dp_ids:
+            raise ValueError(
+                f"Product dp_id '{dp_id}' is classified as a calibrator by "
+                "select_calibrators() and cannot be used as the science target."
+            )
+        table_target = table_target[table_target["dp_id"].astype(str) == dp_id]
+        table_target_hrd = table_target_hrd[
+            table_target_hrd[_dp_id_column(table_target_hrd)].astype(str) == dp_id
+        ]
+
+    elif len(table_target) != 1:
+        warnings.warn(
+            f"Expected exactly 1 science product for target '{target}', "
+            f"but found {len(table_target)}. "
+            "Full candidate dp_id list printed below. "
+            "Please provide one of these with dp_id=... or refine the target "
+            f"selection manually.{_selection_example('dp_id', science_dp_ids)}",
+            stacklevel=2,
+        )
+        sys.stderr.flush()
+        sys.stdout.flush()
+
+        _print_dp_id_list(
+            science_dp_ids,
+            title="Science candidate dp_id values, excluding products classified as calibrators",
+        )
+
+        return None, None, None, None
+
+    elif len(science_dp_ids) != 1:
+        warnings.warn(
+            f"Expected exactly 1 science product for target '{target}', "
+            f"but found {len(science_dp_ids)} after excluding products classified "
+            "as calibrators by select_calibrators(). "
+            "Full candidate dp_id list printed below. "
+            "Please provide one of these with dp_id=... or refine the target "
+            f"selection manually.{_selection_example('dp_id', science_dp_ids)}",
+            stacklevel=2,
+        )
+        sys.stderr.flush()
+        sys.stdout.flush()
+
+        _print_dp_id_list(
+            science_dp_ids,
+            title="Science candidate dp_id values",
+        )
+
+        return None, None, None, None
+
+
 
     proposal_id = table_target["proposal_id"][0]
     obstech = table_target["obstech"][0]
@@ -418,18 +549,50 @@ def get_science_and_calibrator(
         window_hours=window_hours,
     )
 
-    # This simple example expects exactly one calibrator match
-    if len(table_calibrator_hrd) != 1:
+    calibrator_dp_ids = [
+        str(dp_id_candidate)
+        for dp_id_candidate in table_calibrator_hrd[_dp_id_column(table_calibrator_hrd)]
+    ]
+
+    if dp_id_cal is not None:
+        dp_id_cal = str(dp_id_cal).strip()
+        if not dp_id_cal:
+            raise ValueError("dp_id_cal must be a non-empty product id string.")
+        if dp_id_cal not in calibrator_dp_ids:
+            raise ValueError(
+                f"Calibrator product dp_id_cal '{dp_id_cal}' was not found "
+                "among the matched calibrator candidates for this science "
+                f"target. Candidate calibrator dp_id values:\n"
+                f"{_format_dp_id_list(calibrator_dp_ids)}"
+            )
+        table_calibrator_hrd = table_calibrator_hrd[
+            table_calibrator_hrd[_dp_id_column(table_calibrator_hrd)].astype(str)
+            == dp_id_cal
+        ]
+
+    elif len(table_calibrator_hrd) != 1:
         warnings.warn(
             f"Expected exactly 1 matching calibrator for target '{target}', "
             f"but found {len(table_calibrator_hrd)}. "
-            "Please refine the calibrator selection manually."
+            "Full candidate dp_id list printed below. "
+            "Please provide one of these with dp_id_cal=... or refine the "
+            f"calibrator selection manually.{_selection_example('dp_id_cal', calibrator_dp_ids)}",
+            stacklevel=2,
         )
+        sys.stderr.flush()
+        sys.stdout.flush()
+
+        _print_dp_id_list(
+            calibrator_dp_ids,
+            title="Calibrator candidate dp_id values",
+        )
+
         return table_target, None, None, None
 
     # Keep only the matched calibrator product
     table_calibrator = table_calibrator[
-        table_calibrator["dp_id"] == table_calibrator_hrd["DP.ID"][0]
+        table_calibrator["dp_id"].astype(str)
+        == str(table_calibrator_hrd[_dp_id_column(table_calibrator_hrd)][0])
     ]
 
     if len(table_calibrator) != 1:


### PR DESCRIPTION
Merging after initial feedback from Isabelle Percheron

Reorganize and clarify the GRAVITY uncalibrated example notebook: adjust section headings (Part I/II and subsections), add an Acknowledgements section, and refine narrative text for the calibration workflow. Add a new "Optional: Quick Metadata Summary" code cell (print_unique_summary) to inspect unique metadata values and counts. Include a small import placement (astropy.units) needed when running the calibration section mid-notebook, update example download/preview outputs and execution counters, and tighten examples/docs for get_science_and_calibrator (including an explicit usage snippet). Also apply corresponding minor updates to helpers/gravity.py to keep behavior consistent with the notebook changes.