### PR TITLE
Make notebooks test-compliant (#2)

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -24,9 +24,15 @@ jobs:
           import json
           from pathlib import Path
 
-          notebooks = []
+          skip = {
+              "01_authentication.ipynb",
+          }
 
+          notebooks = []
           for p in sorted(Path(".").rglob("*.ipynb")):
+              if p.name in skip:
+                  continue
+
               notebooks.append({
                   "notebook": str(p),
                   "workdir": str(p.parent),
@@ -41,6 +47,7 @@ jobs:
   test:
     needs: discover
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +58,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - run: pip install -r requirements.txt
       - run: pip install pytest nbmake
@@ -64,4 +71,9 @@ jobs:
 
       - name: Execute ${{ matrix.notebook.notebook }}
         run: |
-          pytest --nbmake "${{ matrix.notebook.notebook }}"
+          # Retry five times for flaky connections
+          for i in 1 2 3 4 5; do
+            pytest --nbmake --nbmake-timeout=900 "${{ matrix.notebook.notebook }}" && exit 0
+            sleep 20
+          done
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # Python
 *.pyc
 __pycache__/
+**/.ipynb_checkpoints/

--- a/examples/advanced/04_time_series_spectra.ipynb
+++ b/examples/advanced/04_time_series_spectra.ipynb
@@ -56,6 +56,7 @@
     }
    ],
    "source": [
+    "DOING_SCIENCE = False\n",
     "import astroquery # import astroquery\n",
     "print(f\"astroquery version: {astroquery.__version__}\") # check the version of astroquery"
    ]
@@ -863,7 +864,8 @@
     }
    ],
    "source": [
-    "data_files = eso.retrieve_data(table['dp_id'], destination='./data/') "
+    "n_truncate = None if DOING_SCIENCE else 10\n",
+    "data_files = eso.retrieve_data(table['dp_id'][:n_truncate], destination='./data/') "
    ]
   },
   {
@@ -1180,7 +1182,7 @@
     }
    ],
    "source": [
-    "make_animation = True # Set to True to create the animation, False to skip - may use a lot of RAM\n",
+    "make_animation = False # Set to True to create the animation, False to skip - may use a lot of RAM\n",
     "\n",
     "if make_animation:\n",
     "    print(\"Creating animation... This may take a while, please be patient.\")\n",

--- a/examples/case_studies/helpers/gravity.py
+++ b/examples/case_studies/helpers/gravity.py
@@ -1045,7 +1045,7 @@ def summarize_public(table, use_color=True):
             if use_color:
                 status = f"\033[92m{status}\033[0m"
         else:
-            status = f"restricted (until {date.split("Z")[0]})"
+            status = f"restricted (until {date.split('Z')[0]})"
             if use_color:
                 status = f"\033[91m{status}\033[0m"
 

--- a/examples/simple/01_authentication.ipynb
+++ b/examples/simple/01_authentication.ipynb
@@ -145,6 +145,9 @@
   }
  ],
  "metadata": {
+  "pytest": {
+   "skip": true
+  },
   "kernelspec": {
    "display_name": "tst",
    "language": "python",

--- a/examples/simple/07_observations_download_data.ipynb
+++ b/examples/simple/07_observations_download_data.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eso.login(username=\"TEST\") # authenticate with ESO using a test username\n",
+    "# eso.login(username=\"TEST\") # uncomment to authenticate with ESO using your username\n",
     "\n",
     "data_files = eso.retrieve_data(dp_id) # download the first data product"
    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ tqdm
 PyAstronomy
 astral
 spherical-geometry
+healpy
+ligo.skymap


### PR DESCRIPTION
* Increase timeout and skip animation in advanced/04
* gitignore .ipynb_checkpoints
* Use python 3.10 for testing (astroquery requirement)
* Fix f-string SyntaxError on python < 3.12
* Skip 01_authentication notebook from tests
* Prevent eso.login attempts during tests
* Add healpy and ligo.skymap to requirements.txt
* Add retries for interrupded http connections
* Skip cells requiring esorex and litpro during tests
* Limit data retrieval to n_truncate=10 items